### PR TITLE
Update GNOME runtime to version 47

### DIFF
--- a/io.github.leolost2605.gradebook.json
+++ b/io.github.leolost2605.gradebook.json
@@ -20,6 +20,11 @@
                   "tag": "v1.2",
                   "commit": "8a586057d7b930085c14ca23338e88698ec54ed4" 
               }
+          ],
+          "post-install": [
+              "mkdir -p /app/share/icons/hicolor/scalable/apps",
+              "mv /app/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg",
+              "find /app/share/icons/hicolor -type f -not -path \"*scalable*\" -not -path \"*actions*\" -name \"*.svg\" -delete"
           ]
       }
   ]

--- a/io.github.leolost2605.gradebook.json
+++ b/io.github.leolost2605.gradebook.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.github.leolost2605.gradebook",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "45",
+  "runtime-version": "47",
   "sdk": "org.gnome.Sdk",
   "command": "io.github.leolost2605.gradebook",
   "finish-args": [


### PR DESCRIPTION
GNOME runtime version 45 has reached EOL.